### PR TITLE
synchronize device start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN make -j all
 
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get -y install kmod iproute2 lsof dnsutils
+RUN apt-get update && apt-get -y install kmod iproute2 lsof dnsutils udev
 
 COPY setup-network.sh /
 RUN chmod 755 /setup-network.sh

--- a/setup-network.sh
+++ b/setup-network.sh
@@ -5,6 +5,10 @@ modprobe dummy
 ip link add dnsmasq type dummy || true
 ip link set dnsmasq up
 
+# trigger and wait for udev events to complete
+udevadm trigger
+udevadm settle
+
 # 169.254.20.10 is a link-local address
 # https://tools.ietf.org/html/rfc3927
 ip addr add 169.254.20.10/32 dev dnsmasq || true


### PR DESCRIPTION
trigger and wait for udev event to finish before configuring the ipv4 address. Should eliminate the majority of the false starts and subsequent container restarts by the kubelet.